### PR TITLE
Update Smarty to 3.1.39

### DIFF
--- a/core/model/smarty/Smarty.class.php
+++ b/core/model/smarty/Smarty.class.php
@@ -6,7 +6,7 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
+ * version 3.0 of the License, or (at your option) any later version.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -27,7 +27,6 @@
  * @author    Uwe Tews   <uwe dot tews at gmail dot com>
  * @author    Rodney Rehm
  * @package   Smarty
- * @version   3.1.36
  */
 /**
  * set SMARTY_DIR to absolute path to Smarty library files.
@@ -112,7 +111,7 @@ class Smarty extends Smarty_Internal_TemplateBase
     /**
      * smarty version
      */
-    const SMARTY_VERSION = '3.1.36';
+    const SMARTY_VERSION = '3.1.39';
     /**
      * define variable scopes
      */
@@ -800,7 +799,7 @@ class Smarty extends Smarty_Internal_TemplateBase
      * @param mixed $index    index of directory to get, null to get all
      * @param bool  $isConfig true for config_dir
      *
-     * @return array list of template directories, or directory of $index
+     * @return array|string list of template directories, or directory of $index
      */
     public function getTemplateDir($index = null, $isConfig = false)
     {

--- a/core/model/smarty/SmartyBC.class.php
+++ b/core/model/smarty/SmartyBC.class.php
@@ -6,7 +6,7 @@
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
+ * version 3.0 of the License, or (at your option) any later version.
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU

--- a/core/model/smarty/sysplugins/smarty_internal_compile_function.php
+++ b/core/model/smarty/sysplugins/smarty_internal_compile_function.php
@@ -58,6 +58,11 @@ class Smarty_Internal_Compile_Function extends Smarty_Internal_CompileBase
         }
         unset($_attr[ 'nocache' ]);
         $_name = trim($_attr[ 'name' ], '\'"');
+
+        if (!preg_match('/^[a-zA-Z0-9_\x80-\xff]+$/', $_name)) {
+	        $compiler->trigger_template_error("Function name contains invalid characters: {$_name}", null, true);
+        }
+
         $compiler->parent_compiler->tpl_function[ $_name ] = array();
         $save = array(
             $_attr, $compiler->parser->current_buffer, $compiler->template->compiled->has_nocache_code,

--- a/core/model/smarty/sysplugins/smarty_internal_compile_private_special_variable.php
+++ b/core/model/smarty/sysplugins/smarty_internal_compile_private_special_variable.php
@@ -81,6 +81,10 @@ class Smarty_Internal_Compile_Private_Special_Variable extends Smarty_Internal_C
                 case 'template':
                     return 'basename($_smarty_tpl->source->filepath)';
                 case 'template_object':
+                    if (isset($compiler->smarty->security_policy)) {
+                        $compiler->trigger_template_error("(secure mode) template_object not permitted");
+                        break;
+                    }
                     return '$_smarty_tpl';
                 case 'current_dir':
                     return 'dirname($_smarty_tpl->source->filepath)';
@@ -94,9 +98,9 @@ class Smarty_Internal_Compile_Private_Special_Variable extends Smarty_Internal_C
                         break;
                     }
                     if (strpos($_index[ 1 ], '$') === false && strpos($_index[ 1 ], '\'') === false) {
-                        return "@constant('{$_index[1]}')";
+                        return "(defined('{$_index[1]}') ? constant('{$_index[1]}') : null)";
                     } else {
-                        return "@constant({$_index[1]})";
+                        return "(defined({$_index[1]}) ? constant({$_index[1]}) : null)";
                     }
                 // no break
                 case 'config':

--- a/core/model/smarty/sysplugins/smarty_internal_config_file_compiler.php
+++ b/core/model/smarty/sysplugins/smarty_internal_config_file_compiler.php
@@ -115,7 +115,7 @@ class Smarty_Internal_Config_File_Compiler
             $this->smarty->_debug->start_compile($this->template);
         }
         // init the lexer/parser to compile the config file
-        /* @var Smarty_Internal_ConfigFileLexer $this ->lex */
+        /* @var Smarty_Internal_ConfigFileLexer $this->lex */
         $this->lex = new $this->lexer_class(
             str_replace(
                 array(
@@ -127,7 +127,7 @@ class Smarty_Internal_Config_File_Compiler
             ) . "\n",
             $this
         );
-        /* @var Smarty_Internal_ConfigFileParser $this ->parser */
+        /* @var Smarty_Internal_ConfigFileParser $this->parser */
         $this->parser = new $this->parser_class($this->lex, $this);
         if (function_exists('mb_internal_encoding')
             && function_exists('ini_get')

--- a/core/model/smarty/sysplugins/smarty_internal_errorhandler.php
+++ b/core/model/smarty/sysplugins/smarty_internal_errorhandler.php
@@ -65,7 +65,7 @@ class Smarty_Internal_ErrorHandler
      *
      * @return bool
      */
-    public static function mutingErrorHandler($errno, $errstr, $errfile, $errline, $errcontext)
+    public static function mutingErrorHandler($errno, $errstr, $errfile, $errline, $errcontext = array())
     {
         $_is_muted_directory = false;
         // add the SMARTY_DIR to the list of muted directories

--- a/core/model/smarty/sysplugins/smarty_internal_parsetree_template.php
+++ b/core/model/smarty/sysplugins/smarty_internal_parsetree_template.php
@@ -127,12 +127,12 @@ class Smarty_Internal_ParseTree_Template extends Smarty_Internal_ParseTree
     }
 
     private function getChunkedSubtrees() {
-    	$chunks = [];
+    	$chunks = array();
     	$currentMode = null;
-    	$currentChunk = [];
+    	$currentChunk = array();
 	    for ($key = 0, $cnt = count($this->subtrees); $key < $cnt; $key++) {
 
-	    	if ($this->subtrees[ $key ]->data === '' && in_array($currentMode, ['textstripped', 'text', 'tag'])) {
+	    	if ($this->subtrees[ $key ]->data === '' && in_array($currentMode, array('textstripped', 'text', 'tag'))) {
 	    		continue;
 	    	}
 
@@ -150,19 +150,19 @@ class Smarty_Internal_ParseTree_Template extends Smarty_Internal_ParseTree
 		    if ($newMode == $currentMode) {
 			    $currentChunk[] = $this->subtrees[ $key ];
 		    } else {
-		    	$chunks[] = [
+		    	$chunks[] = array(
 		    		'mode' => $currentMode,
 				    'subtrees' => $currentChunk
-			    ];
+			    );
 		    	$currentMode = $newMode;
-			    $currentChunk = [$this->subtrees[ $key ]];
+			    $currentChunk = array($this->subtrees[ $key ]);
 		    }
 	    }
 	    if ($currentMode && $currentChunk) {
-		    $chunks[] = [
+		    $chunks[] = array(
 			    'mode' => $currentMode,
 			    'subtrees' => $currentChunk
-		    ];
+		    );
 	    }
 		return $chunks;
     }


### PR DESCRIPTION
### What does it do?
Update Smarty to [3.1.39](https://github.com/smarty-php/smarty/releases/tag/v3.1.36)

### Why is it needed?
https://github.com/smarty-php/smarty/blob/master/CHANGELOG.md

### Related issue(s)/PR(s)
NA