### PR TITLE
feat(upgrade): Integrate UpgradeMODX functionality into core

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -83,6 +83,33 @@ $settings['archive_with']->fromArray([
   'area' => 'system',
   'editedon' => null,
 ], '', true, true);
+$settings['core_upgrade_temp_dir'] = $xpdo->newObject(modSystemSetting::class);
+$settings['core_upgrade_temp_dir']->fromArray([
+  'key' => 'core_upgrade_temp_dir',
+  'value' => '',
+  'xtype' => 'textfield',
+  'namespace' => 'core',
+  'area' => 'system',
+  'editedon' => null,
+], '', true, true);
+$settings['core_upgrade_allowed_groups'] = $xpdo->newObject(modSystemSetting::class);
+$settings['core_upgrade_allowed_groups']->fromArray([
+  'key' => 'core_upgrade_allowed_groups',
+  'value' => 'Administrator',
+  'xtype' => 'textfield',
+  'namespace' => 'core',
+  'area' => 'system',
+  'editedon' => null,
+], '', true, true);
+$settings['core_upgrade_force_pcl_zip'] = $xpdo->newObject(modSystemSetting::class);
+$settings['core_upgrade_force_pcl_zip']->fromArray([
+  'key' => 'core_upgrade_force_pcl_zip',
+  'value' => false,
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'system',
+  'editedon' => null,
+], '', true, true);
 $settings['auto_menuindex'] = $xpdo->newObject(modSystemSetting::class);
 $settings['auto_menuindex']->fromArray([
   'key' => 'auto_menuindex',

--- a/_build/test/Tests/Processors/SoftwareUpdate/UpgradeCoreTest.php
+++ b/_build/test/Tests/Processors/SoftwareUpdate/UpgradeCoreTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+ */
+namespace MODX\Revolution\Tests\Processors\SoftwareUpdate;
+
+use MODX\Revolution\Processors\ProcessorResponse;
+use MODX\Revolution\Processors\SoftwareUpdate\UpgradeCore;
+use MODX\Revolution\MODxTestCase;
+
+/**
+ * Tests for SoftwareUpdate/UpgradeCore processor (validation and permission).
+ *
+ * @package modx-test
+ * @subpackage Processors
+ * @group Processors
+ * @group SoftwareUpdate
+ * @group SoftwareUpdateProcessors
+ */
+class UpgradeCoreTest extends MODxTestCase
+{
+    /**
+     * Test that UpgradeCore fails with empty downloadId.
+     */
+    public function testUpgradeCoreFailsWithEmptyDownloadId()
+    {
+        $result = $this->modx->runProcessor(UpgradeCore::class, [
+            'downloadId' => '',
+        ]);
+        $this->assertInstanceOf(ProcessorResponse::class, $result);
+        $this->assertTrue($result->isError());
+    }
+
+    /**
+     * Test that UpgradeCore fails with invalid downloadId format (not a UUID).
+     */
+    public function testUpgradeCoreFailsWithInvalidDownloadId()
+    {
+        $result = $this->modx->runProcessor(UpgradeCore::class, [
+            'downloadId' => 'not-a-valid-uuid',
+        ]);
+        $this->assertInstanceOf(ProcessorResponse::class, $result);
+        $this->assertTrue($result->isError());
+    }
+
+    /**
+     * Test that UpgradeCore fails with malformed downloadId.
+     */
+    public function testUpgradeCoreFailsWithMalformedDownloadId()
+    {
+        $result = $this->modx->runProcessor(UpgradeCore::class, [
+            'downloadId' => 'abc',
+        ]);
+        $this->assertInstanceOf(ProcessorResponse::class, $result);
+        $this->assertTrue($result->isError());
+    }
+}

--- a/core/lexicon/en/dashboard.inc.php
+++ b/core/lexicon/en/dashboard.inc.php
@@ -31,6 +31,9 @@ $_lang['updates_available'] = 'Updates available';
 $_lang['updates_update'] = 'Update';
 $_lang['updates_ok'] = 'Up to date';
 $_lang['updates_extras'] = 'Extras';
+$_lang['updates_upgrade_modx'] = 'Upgrade MODX';
+$_lang['updates_upgrading'] = 'Upgrading MODX...';
+$_lang['updates_badge'] = 'updates';
 
 $_lang['quicklinks'] = 'Quicklinks';
 $_lang['security_notices'] = 'Security Notices';

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -849,3 +849,19 @@ $_lang['setting_passwordless_expiration_desc'] = 'How long a one-time login link
 
 $_lang['setting_static_elements_html_extension'] = 'Static elements html extension';
 $_lang['setting_static_elements_html_extension_desc'] = 'The extension for files used by static elements with HTML content.';
+
+$_lang['invalid_download_id'] = 'Invalid download ID.';
+$_lang['software_update_err_retrieve'] = 'Could not retrieve upgrade package URL.';
+$_lang['software_update_err_temp_dir'] = 'Could not create or write to temporary directory.';
+$_lang['software_update_err_download'] = 'Could not download upgrade package.';
+$_lang['software_update_err_extract'] = 'Could not extract upgrade package.';
+$_lang['software_update_err_archive_structure'] = 'Upgrade archive has unexpected structure.';
+$_lang['software_update_err_copy'] = 'Could not copy upgrade files.';
+$_lang['software_update_err_prepare_setup'] = 'Could not prepare setup (unlock or flush sessions).';
+
+$_lang['setting_core_upgrade_temp_dir'] = 'Core upgrade temp directory';
+$_lang['setting_core_upgrade_temp_dir_desc'] = 'Directory for temporary files during core upgrade. Leave empty for default {core_path}cache/upgrade/.';
+$_lang['setting_core_upgrade_allowed_groups'] = 'Core upgrade allowed groups';
+$_lang['setting_core_upgrade_allowed_groups_desc'] = 'Comma-separated user group names that may run the core upgrade (in addition to users with Settings permission). Default: Administrator.';
+$_lang['setting_core_upgrade_force_pcl_zip'] = 'Core upgrade force PclZip';
+$_lang['setting_core_upgrade_force_pcl_zip_desc'] = 'If Yes, use PclZip instead of ZipArchive when extracting the upgrade package.';

--- a/core/src/Revolution/Processors/SoftwareUpdate/UpgradeCore.php
+++ b/core/src/Revolution/Processors/SoftwareUpdate/UpgradeCore.php
@@ -1,0 +1,352 @@
+<?php
+
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Processors\SoftwareUpdate;
+
+use MODX\Revolution\modSessionHandler;
+use MODX\Revolution\modX;
+use Psr\Http\Client\ClientExceptionInterface;
+
+/**
+ * Downloads the MODX upgrade package from Sentinel, extracts it, copies files
+ * into place, prepares setup, and returns the setup URL for redirect.
+ *
+ * @package MODX\Revolution\Processors\SoftwareUpdate
+ */
+class UpgradeCore extends Base
+{
+    public $permission = 'settings';
+    public $languageTopics = ['setting'];
+
+    /** @var string */
+    private $tempDir;
+
+    /** @var string */
+    private $extractDir;
+
+    /** @var string */
+    private $archiveRoot;
+
+    public function initialize()
+    {
+        if (function_exists('set_time_limit')) {
+            @set_time_limit(0);
+        }
+        return parent::initialize();
+    }
+
+    public function checkPermissions()
+    {
+        if (parent::checkPermissions()) {
+            return true;
+        }
+        $allowedGroups = $this->modx->getOption('core_upgrade_allowed_groups', null, 'Administrator');
+        $groups = array_map('trim', explode(',', $allowedGroups));
+        foreach ($groups as $group) {
+            if ($this->modx->user->isMember($group)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function process()
+    {
+        $downloadId = $this->getProperty('downloadId');
+        if (empty($downloadId) || !$this->isValidDownloadId($downloadId)) {
+            return $this->failure($this->modx->lexicon('invalid_download_id'));
+        }
+
+        $zipUrl = $this->getZipUrl($downloadId);
+        if ($zipUrl === null) {
+            return $this->failure($this->modx->lexicon('software_update_err_retrieve'));
+        }
+
+        $defaultTemp = $this->modx->getOption('core_path') . 'cache/upgrade/';
+        $this->tempDir = rtrim(
+            $this->modx->getOption('core_upgrade_temp_dir', null, $defaultTemp),
+            DIRECTORY_SEPARATOR
+        ) . DIRECTORY_SEPARATOR;
+        if (!is_dir($this->tempDir)) {
+            $this->modx->getCacheManager();
+            if (!$this->modx->cacheManager->writeTree($this->tempDir)) {
+                return $this->failure($this->modx->lexicon('software_update_err_temp_dir'));
+            }
+        }
+
+        $zipPath = $this->downloadZip($zipUrl);
+        if ($zipPath === null) {
+            return $this->failure($this->modx->lexicon('software_update_err_download'));
+        }
+
+        $this->extractDir = $this->tempDir . 'extract' . DIRECTORY_SEPARATOR;
+        if (!$this->extractZip($zipPath)) {
+            $this->cleanup();
+            return $this->failure($this->modx->lexicon('software_update_err_extract'));
+        }
+
+        $this->archiveRoot = $this->findArchiveRoot();
+        if ($this->archiveRoot === null) {
+            $this->cleanup();
+            return $this->failure($this->modx->lexicon('software_update_err_archive_structure'));
+        }
+
+        if (!$this->copyFiles()) {
+            $this->cleanup();
+            return $this->failure($this->modx->lexicon('software_update_err_copy'));
+        }
+
+        if (!$this->prepareSetup()) {
+            $this->cleanup();
+            return $this->failure($this->modx->lexicon('software_update_err_prepare_setup'));
+        }
+
+        $this->cleanup();
+
+        $basePath = rtrim($this->modx->getOption('base_path'), '/') . '/';
+        $redirectUrl = $basePath . 'setup/index.php';
+
+        return $this->success('', ['redirect_url' => $redirectUrl]);
+    }
+
+    private function isValidDownloadId(string $id): bool
+    {
+        return (bool) preg_match('/^[a-f0-9\-]{36}$/i', $id);
+    }
+
+    private function getZipUrl(string $downloadId): ?string
+    {
+        $response = $this->modx->runProcessor(GetFile::class, ['downloadId' => $downloadId]);
+        if ($response->isError()) {
+            return null;
+        }
+        $data = $response->getObject();
+        return isset($data['zip']) && strpos($data['zip'], 'http') === 0 ? $data['zip'] : null;
+    }
+
+    private function downloadZip(string $zipUrl): ?string
+    {
+        $this->initApiClient();
+        $request = $this->apiFactory->createRequest('GET', $zipUrl);
+        try {
+            $response = $this->apiClient->sendRequest($request);
+        } catch (ClientExceptionInterface $e) {
+            $this->modx->log(modX::LOG_LEVEL_ERROR, $e->getMessage());
+            return null;
+        }
+        if ($response->getStatusCode() !== 200) {
+            return null;
+        }
+        $filename = basename(parse_url($zipUrl, PHP_URL_PATH)) ?: 'modx-upgrade.zip';
+        $zipPath = $this->tempDir . $filename;
+        $body = $response->getBody();
+        if (file_put_contents($zipPath, $body->getContents()) === false) {
+            return null;
+        }
+        return $zipPath;
+    }
+
+    private function extractZip(string $zipPath): bool
+    {
+        if (is_dir($this->extractDir)) {
+            $this->removeDirectory($this->extractDir);
+        }
+        if (!mkdir($this->extractDir, 0755, true) && !is_dir($this->extractDir)) {
+            return false;
+        }
+
+        $forcePclZip = (bool) $this->modx->getOption('core_upgrade_force_pcl_zip', null, false);
+
+        if (!$forcePclZip && class_exists(\ZipArchive::class)) {
+            $zip = new \ZipArchive();
+            if ($zip->open($zipPath) === true) {
+                $result = $zip->extractTo($this->extractDir);
+                $zip->close();
+                return $result;
+            }
+        }
+
+        if ($this->modx->getService('archive', 'compression.xPDOZip', XPDO_CORE_PATH, $zipPath)) {
+            $result = $this->modx->archive->unpack($this->extractDir);
+            return $result !== false;
+        }
+
+        return false;
+    }
+
+    private function findArchiveRoot(): ?string
+    {
+        $dirs = array_filter(glob($this->extractDir . '*', GLOB_ONLYDIR), 'is_dir');
+        foreach ($dirs as $dir) {
+            $corePath = $dir . DIRECTORY_SEPARATOR . 'core';
+            $managerPath = $dir . DIRECTORY_SEPARATOR . 'manager';
+            if (is_dir($corePath) && is_dir($managerPath)) {
+                return rtrim($dir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+            }
+        }
+        if (is_dir($this->extractDir . 'core') && is_dir($this->extractDir . 'manager')) {
+            return $this->extractDir;
+        }
+        return null;
+    }
+
+    private function copyFiles(): bool
+    {
+        $basePath = rtrim($this->modx->getOption('base_path'), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        $corePath = rtrim($this->modx->getOption('core_path'), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        $managerPath = rtrim($this->modx->getOption('manager_path'), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        $connectorsPath = rtrim($this->modx->getOption('connectors_path'), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        $assetsPath = rtrim($this->modx->getOption('assets_path'), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+
+        $pairs = [
+            $this->archiveRoot . 'setup' => $basePath . 'setup',
+            $this->archiveRoot . 'core' => $corePath,
+            $this->archiveRoot . 'manager' => $managerPath,
+            $this->archiveRoot . 'connectors' => $connectorsPath,
+        ];
+        if (is_dir($this->archiveRoot . 'assets')) {
+            $pairs[$this->archiveRoot . 'assets'] = $assetsPath;
+        }
+
+        $excludeFromCore = ['config' . DIRECTORY_SEPARATOR . 'config.inc.php'];
+
+        foreach ($pairs as $source => $destination) {
+            if (!is_dir($source)) {
+                continue;
+            }
+            $exclude = [];
+            if ($source === $this->archiveRoot . 'core') {
+                $exclude = $excludeFromCore;
+            }
+            if (!$this->recurseCopy($source, $destination, $exclude)) {
+                return false;
+            }
+        }
+
+        $rootFiles = ['index.php', 'ht.access'];
+        foreach ($rootFiles as $file) {
+            $src = $this->archiveRoot . $file;
+            $dst = $basePath . $file;
+            if (is_file($src)) {
+                if (!copy($src, $dst)) {
+                    return false;
+                }
+            }
+        }
+
+        $sep = DIRECTORY_SEPARATOR;
+        $setupConfigCore = $this->archiveRoot . 'setup' . $sep . 'includes' . $sep . 'config.core.php';
+        if (is_file($setupConfigCore)) {
+            $dstConfigCore = $basePath . 'setup' . $sep . 'includes' . $sep . 'config.core.php';
+            if (!copy($setupConfigCore, $dstConfigCore)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isPathExcluded(string $relative, array $exclude): bool
+    {
+        foreach ($exclude as $ex) {
+            $prefix = $ex . DIRECTORY_SEPARATOR;
+            if ($relative === $ex || strpos($relative, $prefix) === 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function recurseCopy(string $source, string $destination, array $exclude = []): bool
+    {
+        if (!is_dir($destination) && !$this->ensureDirectory($destination)) {
+            return false;
+        }
+        $source = rtrim($source, DIRECTORY_SEPARATOR);
+        $len = strlen($source) + 1;
+        $dir = new \RecursiveDirectoryIterator($source, \RecursiveDirectoryIterator::SKIP_DOTS);
+        $iter = new \RecursiveIteratorIterator($dir, \RecursiveIteratorIterator::SELF_FIRST);
+        foreach ($iter as $item) {
+            $subPath = substr($item->getPathname(), $len);
+            $relative = str_replace('/', DIRECTORY_SEPARATOR, $subPath);
+            if ($this->isPathExcluded($relative, $exclude)) {
+                continue;
+            }
+            $destPath = $destination . DIRECTORY_SEPARATOR . $relative;
+            if ($item->isDir()) {
+                if (!$this->ensureDirectory($destPath)) {
+                    return false;
+                }
+            } elseif (!$this->copyItem($item->getPathname(), $destPath)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private function ensureDirectory(string $path): bool
+    {
+        return is_dir($path) || (mkdir($path, 0755, true) && is_dir($path));
+    }
+
+    private function copyItem(string $source, string $destPath): bool
+    {
+        $destDir = dirname($destPath);
+        if (!$this->ensureDirectory($destDir)) {
+            return false;
+        }
+        if (is_link($source)) {
+            $target = readlink($source);
+            if ($target !== false && !file_exists($destPath)) {
+                @symlink($target, $destPath);
+            }
+            return true;
+        }
+        return copy($source, $destPath);
+    }
+
+    private function prepareSetup(): bool
+    {
+        $basePath = rtrim($this->modx->getOption('base_path'), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        $lockedFile = $basePath . 'setup' . DIRECTORY_SEPARATOR . '.locked';
+        if (file_exists($lockedFile)) {
+            @unlink($lockedFile);
+        }
+        return modSessionHandler::flushSessions($this->modx);
+    }
+
+    private function cleanup(): void
+    {
+        if ($this->tempDir && is_dir($this->tempDir)) {
+            $this->removeDirectory($this->tempDir);
+        }
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        $dir = rtrim($dir, DIRECTORY_SEPARATOR);
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($items as $item) {
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/core/src/Revolution/modManagerController.php
+++ b/core/src/Revolution/modManagerController.php
@@ -139,6 +139,7 @@ abstract class modManagerController
         $this->modx->lexicon->load('action');
         $languageTopics = $this->getLanguageTopics();
         $languageTopics[] = 'trash';
+        $languageTopics[] = 'dashboard';
         foreach ($languageTopics as $topic) {
             $this->modx->lexicon->load($topic);
         }

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -117,7 +118,40 @@ class TopMenu
             'userImage' => $this->getUserImage(),
         ];
 
+        $updateCount = $this->getUpdatesCount();
+        $placeholders['updates_total'] = $updateCount['total'];
+        $placeholders['updates_has_updates'] = $updateCount['total'] > 0;
+
         $this->controller->setPlaceholders($placeholders);
+    }
+
+    /**
+     * Get update counts from cache (same as dashboard updates widget) for navbar badge.
+     *
+     * @return array{modx: int, extras: int, total: int}
+     */
+    protected function getUpdatesCount()
+    {
+        $key = 'mgr/providers/updates/modx-core';
+        $options = [
+            xPDO::OPT_CACHE_KEY => $this->modx->cacheManager->getOption('cache_packages_key', null, 'packages'),
+            xPDO::OPT_CACHE_HANDLER => $this->modx->cacheManager->getOption(
+                'cache_packages_handler',
+                null,
+                $this->modx->cacheManager->getOption(xPDO::OPT_CACHE_HANDLER)
+            ),
+        ];
+        $data = $this->modx->cacheManager->get($key, $options);
+        if (!is_array($data)) {
+            return ['modx' => 0, 'extras' => 0, 'total' => 0];
+        }
+        $modx = (int) (!empty($data['modx']['updateable']));
+        $extras = (int) (!empty($data['extras']['updateable']) ? $data['extras']['updateable'] : 0);
+        return [
+            'modx' => $modx,
+            'extras' => $extras,
+            'total' => $modx + $extras,
+        ];
     }
 
     /**
@@ -165,36 +199,36 @@ class TopMenu
 
             $label = '';
             $description = '';
-            $title = ' title="' . $menu['description'] .'"';
-            $ariaLabel = !empty($menu['description']) ? ' aria-label="' . $menu['description'] .'"' : '';
+            $title = ' title="' . $menu['description'] . '"';
+            $ariaLabel = !empty($menu['description']) ? ' aria-label="' . $menu['description'] . '"' : '';
 
             if (!empty($menu['icon'])) {
                 $label = $menu['icon'];
             } else {
-                $label = '<i class="icon-link icon icon-large"></i>'."\n";
+                $label = '<i class="icon-link icon icon-large"></i>' . "\n";
             }
-            $label .= '<span class="label">'.$menu['text'].'</span>'."\n";
+            $label .= '<span class="label">' . $menu['text'] . '</span>' . "\n";
 
             if ($this->showDescriptions && !empty($menu['description'])) {
-                $description = '<span class="description">'.$menu['description'].'</span>'."\n";
+                $description = '<span class="description">' . $menu['description'] . '</span>' . "\n";
             }
 
             $position = $idx <= 2 && $placeholder == 'navb' ? 'down' : 'up';
 
-            $menuTpl = '<li id="limenu-'.$menu['id'].'"class="menu-'.$position.' top">'."\n";
+            $menuTpl = '<li id="limenu-' . $menu['id'] . '"class="menu-' . $position . ' top">' . "\n";
             if (!empty($menu['action'])) {
                 if ($menu['namespace'] != 'core') {
                     // Handle the namespace
-                    $menu['action'] .= '&namespace='.$menu['namespace'];
+                    $menu['action'] .= '&namespace=' . $menu['namespace'];
                 }
-                $onclick = (!empty($menu['handler'])) ? ' onclick="'.str_replace('"','\'',$menu['handler']).'"' : '';
+                $onclick = (!empty($menu['handler'])) ? ' onclick="' . str_replace('"', '\'', $menu['handler']) . '"' : '';
                 $menuTpl .= '<a href="?a=' . $menu['action'] . $menu['params'] . '"' . $onclick . $title . $ariaLabel . '>' . $label . $description . '</a>' . "\n";
             } elseif (!empty($menu['handler'])) {
-                $menuTpl .= '<a href="javascript:;" onclick="'.str_replace('"','\'',$menu['handler']).'"'.$title.$ariaLabel.'>'.$label.$description.'</a>'."\n";
+                $menuTpl .= '<a href="javascript:;" onclick="' . str_replace('"', '\'', $menu['handler']) . '"' . $title . $ariaLabel . '>' . $label . $description . '</a>' . "\n";
             } else {
-                $menuTpl .= '<a href="javascript:;"'.$title.$ariaLabel.'>'.$label.$description.'</a>'."\n";
+                $menuTpl .= '<a href="javascript:;"' . $title . $ariaLabel . '>' . $label . $description . '</a>' . "\n";
             }
-            $menuTpl .= '</li>'."\n";
+            $menuTpl .= '</li>' . "\n";
 
             if (!empty($menu['children'])) {
                 $this->submenus .= '<ul id="limenu-' . $menu['id'] . '-submenu" class="modx-subnav modx-subnav-' . $menu['parent'] . '">';
@@ -313,28 +347,28 @@ class TopMenu
             }
 
             $sub = (!empty($menu['children'])) ? ' class="sub"' : '';
-            $smTpl = '<li id="'.$menu['id'].'"'.$sub.'>'."\n";
+            $smTpl = '<li id="' . $menu['id'] . '"' . $sub . '>' . "\n";
 
             $description = '';
             if ($this->showDescriptions && !empty($menu['description'])) {
-                $description = '<span class="description">'.$menu['description'].'</span>'."\n";
+                $description = '<span class="description">' . $menu['description'] . '</span>' . "\n";
             }
 
             $attributes = '';
             if (!empty($menu['action'])) {
                 if ($menu['namespace'] != 'core') {
-                    $menu['action'] .= '&namespace='.$menu['namespace'];
+                    $menu['action'] .= '&namespace=' . $menu['namespace'];
                 }
-                $attributes = ' href="?a='.$menu['action'].$menu['params'].'"';
+                $attributes = ' href="?a=' . $menu['action'] . $menu['params'] . '"';
             }
             if (!empty($menu['handler'])) {
-                $attributes .= ' href="javascript:;" onclick="{literal} '.str_replace('"','\'',$menu['handler']).'{/literal} "';
+                $attributes .= ' href="javascript:;" onclick="{literal} ' . str_replace('"', '\'', $menu['handler']) . '{/literal} "';
             }
             $menu['icon'] = $menu['icon'] ?? '';
-            $smTpl .= '<a'.$attributes.' tabindex="0">'.$menu['text'].$menu['icon'].$description.'</a>'."\n";
+            $smTpl .= '<a' . $attributes . ' tabindex="0">' . $menu['text'] . $menu['icon'] . $description . '</a>' . "\n";
 
             if (!empty($menu['children'])) {
-                $smTpl .= '<ul class="modx-subsubnav">'."\n";
+                $smTpl .= '<ul class="modx-subsubnav">' . "\n";
                 $this->processSubMenus($smTpl, $menu['children']);
                 $smTpl .= '</ul><div class="modx-subsubnav-arrow"></div>' . "\n";
             }

--- a/manager/templates/default/dashboard/updates.tpl
+++ b/manager/templates/default/dashboard/updates.tpl
@@ -9,42 +9,54 @@
             </tr>
             </thead>
             <tbody>
-            <tr>
-                <td><span class="updates-title">MODX</span></td>
-                {if $modx.updateable}
-                    <td><span class="updates-available">{$modx.latest.version}</span></td>
-                    <td>
-                        <a 
-                            href="javascript:;"
-                            data-download-id="{$modx.latest.downloadId}"
-                            class="dashboard-button modx"
-                            target="_blank"
-                        >
-                            {$_lang.download}
-                        </a>
-                    </td>
-                {else}
-                    <td><span class="updates-ok">{$_lang.updates_ok}</span></td>
-                    <td><button class="dashboard-button modx" disabled>{$_lang.download}</button></td>
-                {/if}
-            </tr>
-            <tr>
-                {if $extras.updateable}
+            {if $extras.updateable}
+                <tr>
                     <td>
                         <span class="updates-title">{$_lang.updates_extras}</span>
                         <span class="updates-updateable">
                             {if $extras.updateable > 10}10+{else}{$extras.updateable}{/if}
                         </span>
+                        {if $extras.names}
+                            <div class="updates-package-names">
+                                {foreach $extras.names as $pkgName name="pkgList"}
+                                    {if $pkgList@index < 10}{$pkgName|escape}{if $pkgList@index < 9}, {/if}{/if}
+                                {/foreach}
+                                {if $extras.updateable > 10} ...{/if}
+                            </div>
+                        {/if}
                     </td>
                     <td><span class="updates-available">{$_lang.updates_available}</span></td>
                     <td>
                         <a href="{$_config.manager_url}?a=workspaces"
                            class="dashboard-button package">{$_lang.updates_update}</a>
                     </td>
-                {else}
+                </tr>
+            {else}
+                <tr>
                     <td><span class="updates-title">{$_lang.updates_extras}</span></td>
                     <td><span class="updates-ok">{$_lang.updates_ok}</span></td>
                     <td><button class="dashboard-button package" disabled>{$_lang.updates_update}</button></td>
+                </tr>
+            {/if}
+            <tr>
+                <td><span class="updates-title">MODX</span></td>
+                {if $modx.updateable}
+                    <td><span class="updates-available">{$modx.latest.version}</span></td>
+                    <td>
+                        <a href="javascript:;"
+                            data-download-id="{$modx.latest.downloadId}"
+                            class="dashboard-button modx modx-upgrade-btn">
+                            {$_lang.updates_upgrade_modx}
+                        </a>
+                        <a href="javascript:;"
+                            data-download-id="{$modx.latest.downloadId}"
+                            class="dashboard-button modx modx-download-link">
+                            {$_lang.download}
+                        </a>
+                    </td>
+                {else}
+                    <td><span class="updates-ok">{$_lang.updates_ok}</span></td>
+                    <td><button class="dashboard-button modx" disabled>{$_lang.download}</button></td>
                 {/if}
             </tr>
             </tbody>
@@ -54,46 +66,58 @@
 
 {literal}
     <script>
-        const
-            updatesGrid = document.getElementById('modx-grid-updates'),
-            modxLinks = document.querySelectorAll('.dashboard-button.modx')
-        ;
-        modxLinks.forEach(link => {
-            link.addEventListener('click', e => {
-                e.preventDefault();
-                const updatesMask = new Ext.LoadMask(updatesGrid, {
-                    msg: _('downloading')
-                });
-                updatesMask.show();
+        (function() {
+            var grid = document.getElementById('modx-grid-updates');
+            var upgradeBtn = grid && grid.querySelector('.modx-upgrade-btn');
+            var downloadLink = grid && grid.querySelector('.modx-download-link');
+
+            function requestModxUpdate(btn, action, msgKey, onSuccess) {
+                var downloadId = btn.getAttribute('data-download-id');
+                if (!downloadId) return;
+                var mask = new Ext.LoadMask(grid, { msg: _(msgKey) });
+                mask.show();
                 MODx.Ajax.request({
                     url: MODx.config.connector_url,
-                    params: {
-                        action: 'SoftwareUpdate/GetFile',
-                        downloadId: link.dataset.downloadId
-                    },
-                    scope: this,
+                    params: { action: action, downloadId: downloadId },
                     listeners: {
-                        success: {
-                            fn: function(response) {
-                                const url = response.object?.zip;
-                                if (!Ext.isEmpty(url)) {
-                                    window.location.assign(url);
-                                    setTimeout(() => {
-                                        updatesMask.hide();
-                                    }, 1000);
-                                }
-                            },
-                            scope:this
+                        success: function(response) {
+                            onSuccess(response, mask);
                         },
-                        failure: {
-                            fn: function(response) {
-                                updatesMask.hide();
-                            },
-                            scope:this
+                        failure: function() {
+                            mask.hide();
                         }
                     }
                 });
-            });
-        });
+            }
+
+            if (upgradeBtn) {
+                upgradeBtn.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    requestModxUpdate(this, 'SoftwareUpdate/UpgradeCore', 'updates_upgrading', function(response, mask) {
+                        var url = response.object && response.object.redirect_url;
+                        if (url) {
+                            window.location.href = url;
+                        } else {
+                            mask.hide();
+                        }
+                    });
+                });
+            }
+
+            if (downloadLink) {
+                downloadLink.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    requestModxUpdate(this, 'SoftwareUpdate/GetFile', 'downloading', function(response, mask) {
+                        var url = response.object && response.object.zip;
+                        if (url) {
+                            window.location.assign(url);
+                            setTimeout(function() { mask.hide(); }, 1000);
+                        } else {
+                            mask.hide();
+                        }
+                    });
+                });
+            }
+        })();
     </script>
     {/literal}

--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -117,6 +117,14 @@
                 <li id="modx-site-info">
                     <div class="info-item full_appname">{$_version.full_version|strip_tags|escape}</div>
                 </li>
+                {if $updates_has_updates}
+                    <li id="modx-updates-badge" class="modx-updates-badge">
+                        <a href="?" title="{$_lang.updates_available}">
+                            <i class="icon icon-refresh"></i>
+                            <span class="modx-updates-count">{$updates_total} {$_lang.updates_badge}</span>
+                        </a>
+                    </li>
+                {/if}
                 <li id="modx-leftbar-trigger">
                     <a href="javascript:;">
                         <i class="icon"></i>


### PR DESCRIPTION
### What does it do?
Integrates the functionality of the UpgradeMODX package directly into MODX Revolution core:

- **SoftwareUpdate/UpgradeCore processor**: Downloads the MODX upgrade package from Sentinel API, extracts it, copies files into place (excluding config.inc.php), prepares setup, and redirects to setup/index.php
- **Dashboard updates widget**: Adds "Upgrade MODX" button (one-click upgrade) and "Download" link; shows Extras package names when updates are available; displays Extras row first when there are extras updates
- **Navbar badge**: Shows update count (MODX + Extras) in the manager header when updates are available
- **System settings**: core_upgrade_temp_dir, core_upgrade_allowed_groups, core_upgrade_force_pcl_zip
- **Unit tests**: Validation tests for UpgradeCore processor

### Why is it needed?
Eliminates the need for manual FTP file transfers and the UpgradeMODX add-on. Users can upgrade MODX directly from the Manager dashboard with one click. Improves visibility of available updates for both MODX core and Extras.

### How to test
1. Open the Manager dashboard with the Updates widget
2. If a MODX update is available, click "Upgrade MODX" — the upgrade should run and redirect to setup
3. Verify the navbar shows an updates badge when MODX or Extras updates are available
4. Verify Extras row shows package names when extras updates exist
5. Run unit tests: `composer test -- UpgradeCoreTest`

### Related issue(s)/PR(s)
Resolves #13715
Resolves #16660
Resolves #14182